### PR TITLE
[Fix] fixed direction to the left side

### DIFF
--- a/custom_components/ookla_speedtest/www/ookla-speedtest-card-simple.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-card-simple.js
@@ -62,6 +62,7 @@ class OoklaSpeedtestCardSimple extends HTMLElement {
           border-radius: 24px;
           font-family: sans-serif;
           border: 1px solid rgba(255, 255, 255, 0.08);
+          direction: ltr;
         }
         .title { font-size: 18px; margin-bottom: 10px; font-weight: 700; }
         .row { display: flex; justify-content: space-between; margin: 10px 0; }

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-card.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-card.js
@@ -203,6 +203,7 @@ class OoklaSpeedtestCard extends HTMLElement {
           color: #f8fafc;
           position: relative;
           overflow: hidden;
+          direction: ltr;
         }
 
         .card::before {

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-compact.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-compact.js
@@ -86,6 +86,7 @@ class OoklaSpeedtestCompact extends HTMLElement {
           justify-content: space-between;
           border: 1px solid rgba(255, 255, 255, 0.08);
           box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+          direction: ltr;
         }
         .info {
           display: flex;

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-dashboard.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-dashboard.js
@@ -240,6 +240,7 @@ class OoklaSpeedtestDashboard extends HTMLElement {
           border: 1px solid rgba(255, 255, 255, 0.08);
           color: #f8fafc;
           font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+          direction: ltr;
         }
         .header { margin-bottom: 20px; display: flex; justify-content: space-between; align-items: flex-start; }
         .isp-name { font-size: 18px; font-weight: 700; margin-bottom: 4px; color: #f8fafc; }

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-minimal.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-minimal.js
@@ -99,6 +99,7 @@ class OoklaSpeedtestMinimal extends HTMLElement {
           color: #f8fafc;
           font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
           border: 1px solid rgba(255, 255, 255, 0.08);
+          direction: ltr;
         }
         .isp-text {
           font-size: 11px;


### PR DESCRIPTION
RTL users sees the card in wrong positions.
Added `direction: ltr;` to keep it's original layout positions always.