### PR TITLE
Add optional source interface and source ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 - Choose from the 10 nearest servers
 - Manually specify a server ID
 - Optional fallback to closest server if a specified server is temporarily unavailable
+- Optional source interface binding for the speedtest CLI
+- Optional source IP binding for the speedtest CLI
 - **Precise Scheduling**: Run tests at a specific time (e.g., "every hour on the hour")
 - Automatic testing at a configurable interval
 - Manual-only mode for on-demand testing
@@ -110,6 +112,14 @@ All configuration is handled through the Home Assistant UI.
 - Only applies when using a specific server ID
 - Each test still tries the configured server first
 - If Ookla reports that server unavailable, the integration retries with the closest server for that run
+
+#### **Source Interface**
+- Optional
+- Bind the test command to a specific local network interface, such as `eth0` or `wlan0`
+
+#### **Source IP Address**
+- Optional
+- Bind the test command to a specific local source IP address, such as `192.168.1.10`
 
 #### **Manual Mode**
 - **Enabled**: Tests run only when triggered manually

--- a/custom_components/ookla_speedtest/__init__.py
+++ b/custom_components/ookla_speedtest/__init__.py
@@ -3,13 +3,12 @@
 import json
 import logging
 import subprocess
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_call_later, async_track_point_in_time
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
@@ -37,21 +36,23 @@ from .const import (
     ATTR_UPLOAD_LATENCY_HIGH,
     ATTR_UPLOAD_LATENCY_JITTER,
     CONF_FALLBACK_TO_CLOSEST,
+    CONF_MANUAL,
     CONF_ISP_DL_SPEED,
     CONF_ISP_UL_SPEED,
-    CONF_MANUAL,
     CONF_SCAN_INTERVAL,
+    CONF_SOURCE_INTERFACE,
+    CONF_SOURCE_IP,
     CONF_SERVER_ID,
     CONF_START_TIME,
     DEFAULT_FALLBACK_TO_CLOSEST,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    SPEEDTEST_BIN_PATH,
     SERVICE_RUN_SPEEDTEST,
+    SPEEDTEST_BIN_PATH,
     STARTUP_DELAY,
 )
 from .binary_manager import async_setup_speedtest
-from .helpers import validate_server_id
+from .helpers import validate_server_id, validate_source_ip
 from .www_manager import (
     async_setup_cards,
     async_register_resources_service,
@@ -111,6 +112,8 @@ class SpeedtestCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         start_time: str | None = None,
         isp_dl_speed: float | None = None,
         isp_ul_speed: float | None = None,
+        source_interface: str | None = None,
+        source_ip: str | None = None,
         fallback_to_closest: bool = DEFAULT_FALLBACK_TO_CLOSEST,
     ) -> None:
         """Initialize the coordinator."""
@@ -120,6 +123,8 @@ class SpeedtestCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.scan_interval = scan_interval
         self.isp_dl_speed = isp_dl_speed
         self.isp_ul_speed = isp_ul_speed
+        self.source_interface = (source_interface or "").strip() or None
+        self.source_ip = (source_ip or "").strip() or None
         self.fallback_to_closest = fallback_to_closest
         self._unsub_schedule = None
 
@@ -140,7 +145,6 @@ class SpeedtestCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not self.start_time:
             return
 
-        now = dt_util.now()
         try:
             parts = list(map(int, self.start_time.split(":")))
             if len(parts) == 2:
@@ -255,10 +259,13 @@ class SpeedtestCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return None
 
-    @staticmethod
-    def _build_speedtest_cmd(server_id: str | None) -> list[str]:
+    def _build_speedtest_cmd(self, server_id: str | None) -> list[str]:
         """Build the speedtest command for an optional server ID."""
         cmd = [SPEEDTEST_BIN_PATH, "--accept-license", "--accept-gdpr", "--format=json"]
+        if self.source_interface:
+            cmd.extend(["--interface", self.source_interface])
+        if self.source_ip:
+            cmd.extend(["--ip", self.source_ip])
         if server_id:
             cmd.extend(["-s", server_id])
         return cmd
@@ -387,6 +394,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     isp_ul_speed = entry.options.get(
         CONF_ISP_UL_SPEED, entry.data.get(CONF_ISP_UL_SPEED)
     )
+    source_interface = entry.options.get(
+        CONF_SOURCE_INTERFACE, entry.data.get(CONF_SOURCE_INTERFACE)
+    )
+    source_ip = entry.options.get(CONF_SOURCE_IP, entry.data.get(CONF_SOURCE_IP))
     fallback_to_closest = entry.options.get(
         CONF_FALLBACK_TO_CLOSEST,
         entry.data.get(CONF_FALLBACK_TO_CLOSEST, DEFAULT_FALLBACK_TO_CLOSEST),
@@ -399,6 +410,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         server_id = "closest"
 
+    source_interface = (source_interface or "").strip() or None
+    source_ip = (source_ip or "").strip() or None
+
+    if not validate_source_ip(source_ip):
+        _LOGGER.warning(
+            "Invalid source_ip '%s' in config entry; ignoring source IP",
+            source_ip,
+        )
+        source_ip = None
+
     coordinator = SpeedtestCoordinator(
         hass,
         entry,
@@ -408,6 +429,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         start_time,
         isp_dl_speed,
         isp_ul_speed,
+        source_interface,
+        source_ip,
         fallback_to_closest,
     )
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/ookla_speedtest/config_flow.py
+++ b/custom_components/ookla_speedtest/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 from typing import Any
 
 import voluptuous as vol
@@ -12,28 +11,31 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
+from .binary_manager import async_setup_speedtest
 from .const import (
     CONF_ENABLE_COMPLIANCE_SENSORS,
-    CONF_FALLBACK_TO_CLOSEST,
     CONF_ENABLE_LATENCY_SENSORS,
+    CONF_FALLBACK_TO_CLOSEST,
     CONF_ISP_DL_SPEED,
     CONF_ISP_UL_SPEED,
     CONF_MANUAL,
     CONF_SCAN_INTERVAL,
     CONF_SERVER_ID,
+    CONF_SOURCE_INTERFACE,
+    CONF_SOURCE_IP,
     CONF_START_TIME,
     DEFAULT_ENABLE_COMPLIANCE,
-    DEFAULT_FALLBACK_TO_CLOSEST,
     DEFAULT_ENABLE_LATENCY,
+    DEFAULT_FALLBACK_TO_CLOSEST,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from .helpers import (
     get_speedtest_servers,
     validate_server_id,
+    validate_source_ip,
     validate_time_format,
 )
-from .binary_manager import async_setup_speedtest
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +87,8 @@ class OoklaSpeedtestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional("manual_server_id", default=""): str,
                 vol.Optional(CONF_MANUAL, default=True): bool,
+                vol.Optional(CONF_SOURCE_INTERFACE, default=""): str,
+                vol.Optional(CONF_SOURCE_IP, default=""): str,
                 vol.Required(
                     CONF_SCAN_INTERVAL,
                     default=self._minutes_to_duration(DEFAULT_SCAN_INTERVAL),
@@ -121,10 +125,20 @@ class OoklaSpeedtestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             scan_interval = scan_interval_input  # Should not happen with selector
 
         start_time = user_input.get(CONF_START_TIME)
+        source_interface = user_input.get(CONF_SOURCE_INTERFACE, "").strip() or None
+        source_ip = user_input.get(CONF_SOURCE_IP, "").strip() or None
 
         # Validate time format (selector should enforce, but safe to keep)
         if start_time and not validate_time_format(start_time):
             errors[CONF_START_TIME] = "Invalid time format"
+            return self.async_show_form(
+                step_id="user",
+                data_schema=schema,
+                errors=errors,
+            )
+
+        if source_ip and not validate_source_ip(source_ip):
+            errors[CONF_SOURCE_IP] = "Please enter a valid IP address"
             return self.async_show_form(
                 step_id="user",
                 data_schema=schema,
@@ -156,6 +170,8 @@ class OoklaSpeedtestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_data = {
             CONF_SERVER_ID: server_id,
             CONF_MANUAL: user_input[CONF_MANUAL],
+            CONF_SOURCE_INTERFACE: source_interface,
+            CONF_SOURCE_IP: source_ip,
             CONF_SCAN_INTERVAL: scan_interval,
             CONF_START_TIME: start_time,
             CONF_ISP_DL_SPEED: user_input.get(CONF_ISP_DL_SPEED),
@@ -229,6 +245,14 @@ class OoklaSpeedtestOptionsFlow(config_entries.OptionsFlow):
         current_manual = self.config_entry.options.get(
             CONF_MANUAL, self.config_entry.data.get(CONF_MANUAL, True)
         )
+        current_source_interface = self.config_entry.options.get(
+            CONF_SOURCE_INTERFACE,
+            self.config_entry.data.get(CONF_SOURCE_INTERFACE, ""),
+        )
+        current_source_ip = self.config_entry.options.get(
+            CONF_SOURCE_IP,
+            self.config_entry.data.get(CONF_SOURCE_IP, ""),
+        )
         current_scan_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL,
             self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
@@ -275,6 +299,14 @@ class OoklaSpeedtestOptionsFlow(config_entries.OptionsFlow):
                     CONF_MANUAL,
                     default=current_manual,
                 ): bool,
+                vol.Optional(
+                    CONF_SOURCE_INTERFACE,
+                    description={"suggested_value": current_source_interface},
+                ): str,
+                vol.Optional(
+                    CONF_SOURCE_IP,
+                    description={"suggested_value": current_source_ip},
+                ): str,
                 vol.Required(
                     CONF_SCAN_INTERVAL,
                     default=OoklaSpeedtestConfigFlow._minutes_to_duration(
@@ -327,10 +359,20 @@ class OoklaSpeedtestOptionsFlow(config_entries.OptionsFlow):
             scan_interval = scan_interval_input
 
         start_time = user_input.get(CONF_START_TIME)
+        source_interface = user_input.get(CONF_SOURCE_INTERFACE, "").strip() or None
+        source_ip = user_input.get(CONF_SOURCE_IP, "").strip() or None
 
         # Validate time format
         if start_time and not validate_time_format(start_time):
             errors[CONF_START_TIME] = "Invalid time format"
+            return self.async_show_form(
+                step_id="init",
+                data_schema=schema,
+                errors=errors,
+            )
+
+        if source_ip and not validate_source_ip(source_ip):
+            errors[CONF_SOURCE_IP] = "Please enter a valid IP address"
             return self.async_show_form(
                 step_id="init",
                 data_schema=schema,
@@ -365,6 +407,8 @@ class OoklaSpeedtestOptionsFlow(config_entries.OptionsFlow):
             data={
                 CONF_SERVER_ID: server_id,
                 CONF_MANUAL: user_input[CONF_MANUAL],
+                CONF_SOURCE_INTERFACE: source_interface,
+                CONF_SOURCE_IP: source_ip,
                 CONF_SCAN_INTERVAL: scan_interval,
                 CONF_START_TIME: start_time,
                 CONF_ISP_DL_SPEED: user_input.get(CONF_ISP_DL_SPEED),

--- a/custom_components/ookla_speedtest/const.py
+++ b/custom_components/ookla_speedtest/const.py
@@ -5,6 +5,8 @@ DOMAIN = "ookla_speedtest"
 # Configuration
 CONF_SERVER_ID = "server_id"
 CONF_MANUAL = "manual"
+CONF_SOURCE_INTERFACE = "source_interface"
+CONF_SOURCE_IP = "source_ip"
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_START_TIME = "start_time"
 CONF_ISP_DL_SPEED = "isp_dl_speed"

--- a/custom_components/ookla_speedtest/helpers.py
+++ b/custom_components/ookla_speedtest/helpers.py
@@ -1,5 +1,6 @@
 """Helper functions for Ookla Speedtest integration."""
 
+import ipaddress
 import json
 import logging
 import subprocess
@@ -47,6 +48,18 @@ def validate_server_id(server_id: str | None) -> bool:
     if server_id == "closest":
         return True
     return server_id.isdigit()
+
+
+def validate_source_ip(source_ip: str | None) -> bool:
+    """Validate a source IP address."""
+    if not source_ip:
+        return True
+
+    try:
+        ipaddress.ip_address(source_ip)
+        return True
+    except ValueError:
+        return False
 
 
 async def get_speedtest_servers(hass: HomeAssistant) -> list[dict[str, Any]]:

--- a/custom_components/ookla_speedtest/strings.json
+++ b/custom_components/ookla_speedtest/strings.json
@@ -8,6 +8,8 @@
           "server_id": "Speedtest Server",
           "manual_server_id": "Manual Server ID",
           "manual": "Manual Mode",
+          "source_interface": "Source Interface",
+          "source_ip": "Source IP Address",
           "scan_interval": "Scan Interval",
           "start_time": "Start Time",
           "isp_dl_speed": "ISP Download Speed (Mbit/s)",
@@ -20,6 +22,8 @@
           "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers are sorted by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",
           "isp_dl_speed": "Optional: Your rated download speed from your ISP. Used to calculate 'Plan Compliance %'.",
@@ -32,7 +36,8 @@
     },
     "error": {
       "manual_server_id": "Please enter a valid numeric server ID",
-      "server_id": "Invalid server ID selected"
+      "server_id": "Invalid server ID selected",
+      "source_ip": "Please enter a valid IP address"
     },
     "abort": {
       "single_instance_allowed": "Only a single instance is allowed."
@@ -47,6 +52,8 @@
           "server_id": "Speedtest Server",
           "manual_server_id": "Manual Server ID",
           "manual": "Manual Mode",
+          "source_interface": "Source Interface",
+          "source_ip": "Source IP Address",
           "scan_interval": "Scan Interval",
           "start_time": "Start Time",
           "isp_dl_speed": "ISP Download Speed (Mbit/s)",
@@ -59,6 +66,8 @@
           "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers are sorted by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",
           "isp_dl_speed": "Optional: Your rated download speed from your ISP. Used to calculate 'Plan Compliance %'.",
@@ -71,7 +80,8 @@
     },
     "error": {
       "manual_server_id": "Please enter a valid numeric server ID",
-      "server_id": "Invalid server ID selected"
+      "server_id": "Invalid server ID selected",
+      "source_ip": "Please enter a valid IP address"
     }
   }
 }

--- a/custom_components/ookla_speedtest/translations/en.json
+++ b/custom_components/ookla_speedtest/translations/en.json
@@ -8,6 +8,8 @@
           "server_id": "Speedtest Server",
           "manual_server_id": "Manual Server ID",
           "manual": "Manual Mode",
+          "source_interface": "Source Interface",
+          "source_ip": "Source IP Address",
           "scan_interval": "Scan Interval",
           "start_time": "Start Time",
           "isp_dl_speed": "ISP Download Speed (Mbit/s)",
@@ -20,6 +22,8 @@
           "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",
           "isp_dl_speed": "Optional: Your rated download speed from your ISP. Used to calculate 'Plan Compliance %'.",
@@ -32,7 +36,8 @@
     },
     "error": {
       "manual_server_id": "Please enter a valid numeric server ID",
-      "server_id": "Invalid server ID selected"
+      "server_id": "Invalid server ID selected",
+      "source_ip": "Please enter a valid IP address"
     },
     "abort": {
       "single_instance_allowed": "Only a single instance is allowed."

--- a/custom_components/ookla_speedtest/translations/en.json
+++ b/custom_components/ookla_speedtest/translations/en.json
@@ -7,9 +7,9 @@
         "data": {
           "server_id": "Speedtest Server",
           "manual_server_id": "Manual Server ID",
-          "manual": "Manual Mode",
           "source_interface": "Source Interface",
           "source_ip": "Source IP Address",
+          "manual": "Manual Mode",
           "scan_interval": "Scan Interval",
           "start_time": "Start Time",
           "isp_dl_speed": "ISP Download Speed (Mbit/s)",
@@ -19,11 +19,11 @@
           "fallback_to_closest": "Fall Back to Closest Server"
         },
         "data_description": {
-          "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers by distance.",
+          "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers are sorted by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0. If not filled, the default route interface will be used.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10. If not filled, the IP address of the default route interface will be used.",         "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
-          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0.",
-          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",
           "isp_dl_speed": "Optional: Your rated download speed from your ISP. Used to calculate 'Plan Compliance %'.",
@@ -51,6 +51,8 @@
         "data": {
           "server_id": "Speedtest Server",
           "manual_server_id": "Manual Server ID",
+          "source_interface": "Source Interface",
+          "source_ip": "Source IP Address",
           "manual": "Manual Mode",
           "scan_interval": "Scan Interval",
           "start_time": "Start Time",
@@ -61,8 +63,10 @@
           "fallback_to_closest": "Fall Back to Closest Server"
         },
         "data_description": {
-          "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers by distance.",
+          "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers are sorted by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0. If not filled, the default route interface will be used.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10. If not filled, the IP address of the default route interface will be used.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",
@@ -76,7 +80,8 @@
     },
     "error": {
       "manual_server_id": "Please enter a valid numeric server ID",
-      "server_id": "Invalid server ID selected"
+      "server_id": "Invalid server ID selected",
+      "source_ip": "Please enter a valid IP address"
     }
   }
 }

--- a/custom_components/ookla_speedtest/translations/en.json
+++ b/custom_components/ookla_speedtest/translations/en.json
@@ -22,7 +22,7 @@
           "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers are sorted by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
           "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0. If not filled, the default route interface will be used.",
-          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10. If not filled, the IP address of the default route interface will be used.",         "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10. If not filled, the IP address of the default route interface will be used.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",


### PR DESCRIPTION
Ookla speedtest-cli allows to configure source interface name and/or source IP address. This is usable when you have multiple WANs (internet connections) and would like to test all of them or specific one. What is possible to do both on HassOS or other HA instalation types is to add additional interface or just secondary IP on the existing one and then use source based routing on your router to point given source IP to the given WAN link.

The proposed change allows to specify optional source interface and/or IP so use such source based routing and test multiple WANs.

- I tested the PR successfully on two WANs.
- This PR doesn't break backward compatibilty