### PR TITLE
Run selected test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 ```yaml
 service: ookla_speedtest.run_speedtest
 ```
-- Optionally pass `device_id` to run one configured test; if omitted, the service runs all configured tests.
+- Optionally pass `entity_id` (recommended for cards) or `device_id` to run one configured test; if omitted, the service runs all configured tests.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 ```yaml
 service: ookla_speedtest.run_speedtest
 ```
+- Optionally pass `config_entry_id` to run one configured test; if omitted, the service runs all configured tests.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 ```yaml
 service: ookla_speedtest.run_speedtest
 ```
-- Optionally pass `config_entry_id` to run one configured test; if omitted, the service runs all configured tests.
+- Optionally pass `device_id` to run one configured test; if omitted, the service runs all configured tests.
 
 
 ## Installation

--- a/custom_components/ookla_speedtest/__init__.py
+++ b/custom_components/ookla_speedtest/__init__.py
@@ -9,9 +9,14 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEVICE_ID, EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import device_registry as dr, selector
+from homeassistant.helpers import device_registry as dr, entity_registry as er, selector
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_point_in_time,
@@ -73,6 +78,11 @@ RUN_SPEEDTEST_SCHEMA = vol.Schema(
         vol.Optional(ATTR_DEVICE_ID): selector.DeviceSelector(
             selector.DeviceSelectorConfig(
                 filter=selector.DeviceFilterSelectorConfig(integration=DOMAIN)
+            )
+        ),
+        vol.Optional(ATTR_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(
+                filter=selector.EntityFilterSelectorConfig(integration=DOMAIN)
             )
         ),
     }
@@ -431,14 +441,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def run_speedtest_service(call: ServiceCall) -> None:
         """Service to manually run a speedtest."""
         device_id = call.data.get(ATTR_DEVICE_ID)
+        entity_id = call.data.get(ATTR_ENTITY_ID)
         coordinators: list[SpeedtestCoordinator]
 
-        if device_id:
+        def _coordinator_from_device(selected_device_id: str) -> SpeedtestCoordinator | None:
+            """Resolve a speedtest coordinator from a device ID."""
             device_registry = dr.async_get(hass)
-            device_entry = device_registry.async_get(device_id)
+            device_entry = device_registry.async_get(selected_device_id)
             if device_entry is None:
-                _LOGGER.warning("Unknown Ookla Speedtest device requested: %s", device_id)
-                return
+                _LOGGER.warning(
+                    "Unknown Ookla Speedtest device requested: %s",
+                    selected_device_id,
+                )
+                return None
 
             matching_entry_id = next(
                 (
@@ -454,9 +469,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if matching_entry_id is None:
                 _LOGGER.warning(
                     "Ookla Speedtest device is not linked to a loaded config entry: %s",
-                    device_id,
+                    selected_device_id,
                 )
-                return
+                return None
 
             config_entry = hass.config_entries.async_get_entry(matching_entry_id)
             if config_entry is None:
@@ -464,7 +479,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Ookla Speedtest config entry is not ready: %s",
                     matching_entry_id,
                 )
-                return
+                return None
 
             coordinator = hass.data[DOMAIN].get(config_entry.entry_id)
             if coordinator is None:
@@ -472,6 +487,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Ookla Speedtest config entry is not ready: %s",
                     config_entry.title,
                 )
+                return None
+
+            return coordinator
+
+        if device_id:
+            coordinator = _coordinator_from_device(device_id)
+            if coordinator is None:
+                return
+            coordinators = [coordinator]
+        elif entity_id:
+            entity_entry = er.async_get(hass).async_get(entity_id)
+            if entity_entry is None:
+                _LOGGER.warning(
+                    "Unknown Ookla Speedtest entity requested: %s",
+                    entity_id,
+                )
+                return
+
+            if entity_entry.device_id is None:
+                _LOGGER.warning(
+                    "Ookla Speedtest entity is not linked to a device: %s",
+                    entity_id,
+                )
+                return
+
+            coordinator = _coordinator_from_device(entity_entry.device_id)
+            if coordinator is None:
                 return
             coordinators = [coordinator]
         else:

--- a/custom_components/ookla_speedtest/__init__.py
+++ b/custom_components/ookla_speedtest/__init__.py
@@ -9,13 +9,9 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_CONFIG_ENTRY_ID,
-    EVENT_HOMEASSISTANT_STARTED,
-    Platform,
-)
+from homeassistant.const import ATTR_DEVICE_ID, EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import selector, service
+from homeassistant.helpers import device_registry as dr, selector, service
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_point_in_time,
@@ -74,8 +70,10 @@ PLATFORMS = [Platform.SENSOR]
 
 RUN_SPEEDTEST_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
-            {"integration": DOMAIN}
+        vol.Optional(ATTR_DEVICE_ID): selector.DeviceSelector(
+            selector.DeviceSelectorConfig(
+                filter=selector.DeviceFilterSelectorConfig(integration=DOMAIN)
+            )
         ),
     }
 )
@@ -432,13 +430,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register service to manually run a speed test
     async def run_speedtest_service(call: ServiceCall) -> None:
         """Service to manually run a speedtest."""
-        config_entry_id = call.data.get(ATTR_CONFIG_ENTRY_ID)
+        device_id = call.data.get(ATTR_DEVICE_ID)
         coordinators: list[SpeedtestCoordinator]
 
-        if config_entry_id:
-            config_entry = service.async_get_config_entry(
-                hass, DOMAIN, config_entry_id
+        if device_id:
+            device_registry = dr.async_get(hass)
+            device_entry = device_registry.async_get(device_id)
+            if device_entry is None:
+                _LOGGER.warning("Unknown Ookla Speedtest device requested: %s", device_id)
+                return
+
+            matching_entry_id = next(
+                (
+                    entry_id
+                    for entry_id in device_entry.config_entries
+                    if (
+                        entry := hass.config_entries.async_get_entry(entry_id)
+                    ) is not None
+                    and entry.domain == DOMAIN
+                ),
+                None,
             )
+            if matching_entry_id is None:
+                _LOGGER.warning(
+                    "Ookla Speedtest device is not linked to a loaded config entry: %s",
+                    device_id,
+                )
+                return
+
+            config_entry = service.async_get_config_entry(hass, DOMAIN, matching_entry_id)
             coordinator = hass.data[DOMAIN].get(config_entry.entry_id)
             if coordinator is None:
                 _LOGGER.warning(

--- a/custom_components/ookla_speedtest/__init__.py
+++ b/custom_components/ookla_speedtest/__init__.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_ID, EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import device_registry as dr, selector, service
+from homeassistant.helpers import device_registry as dr, selector
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_point_in_time,
@@ -458,7 +458,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
                 return
 
-            config_entry = service.async_get_config_entry(hass, DOMAIN, matching_entry_id)
+            config_entry = hass.config_entries.async_get_entry(matching_entry_id)
+            if config_entry is None:
+                _LOGGER.warning(
+                    "Ookla Speedtest config entry is not ready: %s",
+                    matching_entry_id,
+                )
+                return
+
             coordinator = hass.data[DOMAIN].get(config_entry.entry_id)
             if coordinator is None:
                 _LOGGER.warning(

--- a/custom_components/ookla_speedtest/__init__.py
+++ b/custom_components/ookla_speedtest/__init__.py
@@ -6,11 +6,20 @@ import subprocess
 from datetime import datetime, timedelta
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.event import async_call_later, async_track_point_in_time
+from homeassistant.helpers import selector, service
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_point_in_time,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
@@ -62,6 +71,14 @@ from .www_manager import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
+
+RUN_SPEEDTEST_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+            {"integration": DOMAIN}
+        ),
+    }
+)
 
 
 async def async_setup_cards_and_resources(hass: HomeAssistant) -> None:
@@ -415,14 +432,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register service to manually run a speed test
     async def run_speedtest_service(call: ServiceCall) -> None:
         """Service to manually run a speedtest."""
-        # Clear sensor data before running test to avoid confusion with old data
-        coordinator.async_set_updated_data(None)
-        await coordinator.async_request_refresh()
+        config_entry_id = call.data.get(ATTR_CONFIG_ENTRY_ID)
+        coordinators: list[SpeedtestCoordinator]
+
+        if config_entry_id:
+            config_entry = service.async_get_config_entry(
+                hass, DOMAIN, config_entry_id
+            )
+            coordinator = hass.data[DOMAIN].get(config_entry.entry_id)
+            if coordinator is None:
+                _LOGGER.warning(
+                    "Ookla Speedtest config entry is not ready: %s",
+                    config_entry.title,
+                )
+                return
+            coordinators = [coordinator]
+        else:
+            coordinators = list(hass.data[DOMAIN].values())
+
+        for item in coordinators:
+            item.async_set_updated_data(None)
+            await item.async_request_refresh()
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_RUN_SPEEDTEST,
         run_speedtest_service,
+        schema=RUN_SPEEDTEST_SCHEMA,
     )
 
     # Delay first speedtest in interval mode to avoid blocking HA startup
@@ -462,9 +498,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.services.async_remove(DOMAIN, SERVICE_RUN_SPEEDTEST)
         if entry.entry_id in hass.data[DOMAIN]:
             hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN] and hass.services.has_service(DOMAIN, SERVICE_RUN_SPEEDTEST):
+            hass.services.async_remove(DOMAIN, SERVICE_RUN_SPEEDTEST)
 
     return unload_ok
 

--- a/custom_components/ookla_speedtest/services.yaml
+++ b/custom_components/ookla_speedtest/services.yaml
@@ -1,7 +1,13 @@
 run_speedtest:
   name: Run Speedtest
-  description: Manually trigger an Ookla Speedtest run.
-  fields: {}
+  description: Manually trigger one or all configured Ookla Speedtest runs.
+  fields:
+    config_entry_id:
+      name: Config Entry
+      description: Optional Ookla Speedtest config entry to run only that configured test. If omitted, all configured tests are run.
+      selector:
+        config_entry:
+          integration: ookla_speedtest
 
 register_card_resources:
   name: Register Card Resources

--- a/custom_components/ookla_speedtest/services.yaml
+++ b/custom_components/ookla_speedtest/services.yaml
@@ -2,6 +2,13 @@ run_speedtest:
   name: Run Speedtest
   description: Manually trigger one or all configured Ookla Speedtest runs.
   fields:
+    entity_id:
+      name: Entity
+      description: Optional Ookla Speedtest entity to run only that configured test device.
+      selector:
+        entity:
+          filter:
+            integration: ookla_speedtest
     device_id:
       name: Device
       description: Optional Ookla Speedtest device to run only that configured test. If omitted, all configured tests are run.

--- a/custom_components/ookla_speedtest/services.yaml
+++ b/custom_components/ookla_speedtest/services.yaml
@@ -2,12 +2,13 @@ run_speedtest:
   name: Run Speedtest
   description: Manually trigger one or all configured Ookla Speedtest runs.
   fields:
-    config_entry_id:
-      name: Config Entry
-      description: Optional Ookla Speedtest config entry to run only that configured test. If omitted, all configured tests are run.
+    device_id:
+      name: Device
+      description: Optional Ookla Speedtest device to run only that configured test. If omitted, all configured tests are run.
       selector:
-        config_entry:
-          integration: ookla_speedtest
+        device:
+          filter:
+            integration: ookla_speedtest
 
 register_card_resources:
   name: Register Card Resources

--- a/custom_components/ookla_speedtest/translations/en.json
+++ b/custom_components/ookla_speedtest/translations/en.json
@@ -19,6 +19,8 @@
         "data_description": {
           "server_id": "Choose which server to test against. 'Closest Server' automatically selects the nearest server. Servers by distance.",
           "manual_server_id": "Enter a specific server ID number (only used if 'Manual Server ID' is selected above). Find server IDs at speedtest.net/servers.",
+          "source_interface": "Optional: Bind tests to a specific network interface name, such as eth0 or wlan0. If not filled, the default route interface will be used.",
+          "source_ip": "Optional: Bind tests to a specific local source IP address, such as 192.168.1.10. If not filled, the IP address of the default route interface will be used.",
           "manual": "When enabled, speed tests will only run when manually triggered via the 'run_speedtest' service. When disabled, tests run automatically based on the scan interval.",
           "scan_interval": "How often to automatically run speed tests. Default is 24 hours. Only applies when Manual Mode is disabled. Lower values will use more bandwidth.",
           "start_time": "Optional: Time to align the schedule (e.g., '14:00'). If set, the first test runs at this time, then every 'Scan Interval'. Useful for 'every hour on the hour' (Set 00:00 and interval 1 hour).",

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-card-simple.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-card-simple.js
@@ -164,7 +164,12 @@ class OoklaSpeedtestCardSimple extends HTMLElement {
     if (btn) {
       btn.addEventListener('click', () => {
         if (this._hass) {
-          this._hass.callService('ookla_speedtest', 'run_speedtest');
+          const entityId =
+            this._config?.entities?.download ||
+            this._config?.entities?.ping ||
+            this._config?.entities?.upload ||
+            'sensor.ookla_speedtest_download';
+          this._hass.callService('ookla_speedtest', 'run_speedtest', { entity_id: entityId });
           btn.textContent = 'Testing...';
           setTimeout(() => btn.textContent = 'GO', 3000);
         }

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-card.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-card.js
@@ -222,6 +222,11 @@ class OoklaSpeedtestCard extends HTMLElement {
 
   _runSpeedtest() {
     if (this._isRunning) return;
+
+    const entityId =
+      this._config?.entities?.download ||
+      this._config?.entities?.ping ||
+      this._config?.entities?.upload;
     
     this._isRunning = true;
     const btn = this.shadowRoot.querySelector('.go-button');
@@ -230,7 +235,8 @@ class OoklaSpeedtestCard extends HTMLElement {
       btn.textContent = '...';
     }
 
-    this._hass.callService('ookla_speedtest', 'run_speedtest').then(() => {
+    const serviceData = entityId ? { entity_id: entityId } : {};
+    this._hass.callService('ookla_speedtest', 'run_speedtest', serviceData).then(() => {
       setTimeout(() => {
         this._isRunning = false;
         if (btn) {

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-compact.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-compact.js
@@ -122,7 +122,16 @@ class OoklaSpeedtestCompact extends HTMLElement {
   _runTest() {
     if (!this._hass) return;
 
-    this._hass.callService('ookla_speedtest', 'run_speedtest');
+    const entityId =
+      this._config?.entities?.download ||
+      this._config?.entities?.ping ||
+      this._config?.entities?.upload;
+
+    this._hass.callService(
+      'ookla_speedtest',
+      'run_speedtest',
+      entityId ? { entity_id: entityId } : {}
+    );
     const btn = this.shadowRoot.querySelector('.action-button');
     if (btn) {
       btn.classList.add('running');

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-dashboard.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-dashboard.js
@@ -864,7 +864,15 @@ class OoklaSpeedtestDashboard extends HTMLElement {
       const el = this.shadowRoot.querySelector(id);
       if (!el) return;
       if (id === '#run') el.onclick = () => {
-        this._hass.callService('ookla_speedtest', 'run_speedtest');
+        const runEntityId =
+          e.download ||
+          e.ping ||
+          e.upload;
+        this._hass.callService(
+          'ookla_speedtest',
+          'run_speedtest',
+          runEntityId ? { entity_id: runEntityId } : {}
+        );
         el.classList.add('running');
         setTimeout(() => el.classList.remove('running'), 5000);
       };

--- a/custom_components/ookla_speedtest/www/ookla-speedtest-minimal.js
+++ b/custom_components/ookla_speedtest/www/ookla-speedtest-minimal.js
@@ -132,7 +132,15 @@ class OoklaSpeedtestMinimal extends HTMLElement {
 
   _runTest() {
     if (this._hass) {
-      this._hass.callService('ookla_speedtest', 'run_speedtest');
+      const entityId =
+        this._config?.entities?.download ||
+        this._config?.entities?.ping ||
+        this._config?.entities?.upload;
+      this._hass.callService(
+        'ookla_speedtest',
+        'run_speedtest',
+        entityId ? { entity_id: entityId } : {}
+      );
       const btn = this.shadowRoot.querySelector('.test-btn');
       if (btn) {
         btn.textContent = 'Testing...';


### PR DESCRIPTION
Currently the run_speedtest service trigger run of all configured test at the same time. This is not desired, as user might want to select only given test or execute test in series not in parallel as it might affect speed test results.

This change implements optional selector of the device_id o be specified for run_speedtest. If not specified test will be executed not in parallel but in serial manner.

- I tested the behaviour as desired on the 2 configured tests.
- Implemented changes are non breaking.

This PR was previously implemented on the top of my PR #31, there might be some conflicts. If would would merge #31 I can recreate this PR against it fro clean merge.